### PR TITLE
Fixing import from package Pillow

### DIFF
--- a/cropper/models.py
+++ b/cropper/models.py
@@ -3,7 +3,7 @@ from django.utils.translation import ugettext_lazy as _
 from django.core.exceptions import ValidationError
 from django.conf import settings as django_settings
 from cropper import settings
-import Image
+from PIL import Image
 import os
 import uuid
 


### PR DESCRIPTION
For some reason "import Image" doesn't work with Pillow ver. 2.4
I don't know about other versions.
"from PIL import Image" on the other hand does work.
I'm pretty sure this change should also be compatible with PIL but I haven't tested it.
